### PR TITLE
chore: Add cleanup policy and push PR images to separate registry name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,16 @@ jobs:
         id: meta
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "controller=images/chantico" >> $GITHUB_OUTPUT
+            echo "snmp=images/chantico-snmp-mock" >> $GITHUB_OUTPUT
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "controller=images/chantico-pr" >> $GITHUB_OUTPUT
+            echo "snmp=images/chantico-snmp-mock-pr" >> $GITHUB_OUTPUT
             echo "tag=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
           else
+            echo "controller=images/chantico" >> $GITHUB_OUTPUT
+            echo "snmp=images/chantico-snmp-mock" >> $GITHUB_OUTPUT
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 
@@ -106,7 +112,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/images/chantico:${{ steps.meta.outputs.tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ steps.meta.outputs.controller }}:${{ steps.meta.outputs.tag }}
 
       - name: Build and push snmp-mock
         uses: docker/build-push-action@v7
@@ -114,7 +120,7 @@ jobs:
           context: .
           file: ./Dockerfile.snmp-mock
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/images/chantico-snmp-mock:${{ steps.meta.outputs.tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ steps.meta.outputs.snmp }}:${{ steps.meta.outputs.tag }}
 
   # Documentation build
   docs:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,6 +17,8 @@ jobs:
     strategy:
       matrix:
         package:
+          - images/chantico
+          - images/chantico-snmp-mock
           - images/chantico-pr
           - images/chantico-snmp-mock-pr
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,37 @@
+name: Cleanup PR Docker Images
+
+on:
+  schedule:
+    # Run every Sunday at 04:00 UTC
+    - cron: "0 4 * * 0"
+  workflow_dispatch: # Allow manual trigger of workflow
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        package:
+          - images/chantico-pr
+          - images/chantico-snmp-mock-pr
+
+    steps:
+      - name: Delete old PR container versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.package }}
+          package-type: container
+          owner: ${{ github.repository_owner }}
+
+          # Keep the newest 10 versions
+          min-versions-to-keep: 10
+
+          # Match tags like pr-123, keep anything else pushed to these registries
+          ignore-versions: '^(?!pr-).*'
+
+          token: ${{ secrets.BOT_RELEASE_TOKEN }}


### PR DESCRIPTION
## Description

This adds a cleanup workflow to remove older images that were created from pull requests as they are unlikely to remain in use for longer periods, and also moves them from being pushed to the main registry image name to another PR-only image name.

## How to test

- Observe how the Docker build check from this PR's CI run pushes images to another image name successfully (with the bot release token to write into the registry).
- Manually run the cleanup job (it may need to be merged to main before this is possible?)

## Linked issue

#115

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [ ] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
