### PR TITLE
docs: Document storage class override

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ website](https://chantico-project.github.io/chantico/).
 For a quick start, install Chantico on your k8s cluster using:
 
 ```bash
-helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico # Latest version
+helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico --create-namespace # Latest version
 ```
 
 For more information have a look at the following [installation 
-guide](https://chantico-project.github.io/chantico/how-tos/how-to-install-chantico/). For a local setup of Chantico, please 
+guide](https://chantico-project.github.io/chantico/how-tos/how-to-install-chantico/). If
+your cluster does not use the default `csi-rbd` storage class, pass the
+available class with `--set pvc.storageClassName="<storage class name>"`. For a
+local setup of Chantico, please
 have a look at the following 
 [guide](https://chantico-project.github.io/chantico/how-tos/how-to-setup-the-local-development-environment/).
 

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -5,12 +5,6 @@ set -ex
 SCRIPT_DIR=$(dirname -- "$( readlink -f -- "$0"; )")
 SNMP_MOCK_TAG="${SNMP_MOCK_TAG:-latest}"
 
-# get kind
-go install sigs.k8s.io/kind@v0.30.0
-
-# If go is not yet added to $PATH:
-#echo 'export PATH="$(go env GOPATH)/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
-
 kind create cluster --config "$SCRIPT_DIR/kind-config.yaml"
 
 kubectl create namespace chantico

--- a/docs/how-tos/how-to-install-chantico.md
+++ b/docs/how-tos/how-to-install-chantico.md
@@ -21,8 +21,9 @@ helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico
 ### Configure the storage class
 
 The chart creates a PersistentVolumeClaim for Prometheus data and defaults to
-the `csi-rbd` storage class. Clusters such as Docker Desktop, kind, minikube or
-managed Kubernetes installations may expose a different storage class.
+the `csi-rbd` storage class. Clusters such as Docker Desktop,
+[kind](https://kind.sigs.k8s.io/), minikube or managed Kubernetes installations
+may expose a different storage class.
 
 List the storage classes available in your cluster:
 

--- a/docs/how-tos/how-to-install-chantico.md
+++ b/docs/how-tos/how-to-install-chantico.md
@@ -11,12 +11,36 @@ menus:
 The easiest option to install Chantico into your k8s cluster is by using the helm package from the OCI Registry.
 
 ```bash
-helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico # Latest version
+helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico --create-namespace # Latest version
 ```
 
 - The command above installs the latest version of Chantico. See available [chart versions](https://github.com/chantico-project/chantico/pkgs/container/charts%2Fchantico). Also check out the [releases](https://github.com/chantico-project/chantico/releases) or the [changelog](/technical/changelog.md) on the documentation website for the list of changes throughout the version history.
 
 - Inspect the [values.yaml](https://github.com/chantico-project/chantico/blob/main/config/deployment/values.yaml) file to see what parameters can be provided. For example, excluding the Chantico controller from the installation can be done with `--set controller.include=false`.
+
+### Configure the storage class
+
+The chart creates a PersistentVolumeClaim for Prometheus data and defaults to
+the `csi-rbd` storage class. Clusters such as Docker Desktop, kind, minikube or
+managed Kubernetes installations may expose a different storage class.
+
+List the storage classes available in your cluster:
+
+```bash
+kubectl get storageclass
+```
+
+Then pass the storage class name during installation:
+
+```bash
+helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico --create-namespace --set pvc.storageClassName="<storage class name>"
+```
+
+For example, the local development setup uses Rancher's local path provisioner:
+
+```bash
+helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico --create-namespace --set pvc.storageClassName="local-path"
+```
 
 ## Upgrading using OCI Registry
 

--- a/docs/how-tos/how-to-setup-the-local-development-environment.md
+++ b/docs/how-tos/how-to-setup-the-local-development-environment.md
@@ -19,7 +19,8 @@ It requires the following packages:
 - make version 4.3+
 - kubectl version v0.30.0+
 
-Install `kind` through your preferred package manager, standalone binary or Go:
+Install [kind](https://kind.sigs.k8s.io/) through your preferred package
+manager, standalone binary or Go:
 
 ```bash
 go install sigs.k8s.io/kind@v0.30.0

--- a/docs/how-tos/how-to-setup-the-local-development-environment.md
+++ b/docs/how-tos/how-to-setup-the-local-development-environment.md
@@ -19,6 +19,12 @@ It requires the following packages:
 - make version 4.3+
 - kubectl version v0.30.0+
 
+Install `kind` through your preferred package manager, standalone binary or Go:
+
+```bash
+go install sigs.k8s.io/kind@v0.30.0
+```
+
 ### Installation
 
 - To install the kind docker cluster, run:


### PR DESCRIPTION
﻿## Summary
- add `--create-namespace` to the quick Helm install commands
- document how to discover and override `pvc.storageClassName`
- move `kind` installation guidance into the local setup docs instead of installing it inside `dev/setup.sh`

## Testing
- `git diff --check`
- verified the updated docs include the storage class override and `kind` install guidance with `rg`

Fixes #120
