### PR TITLE
fix(release): Ensure CRDs and full image registries are included in Helm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,13 @@ jobs:
             git commit -m "bump version to v$VERSION [skip ci]"
             git push https://$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY HEAD:${GITHUB_REF_NAME}
           fi
+          NEW_SHA=$(git rev-parse HEAD)
+          for i in {1..20}; do
+            if git ls-remote https://$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY | grep $NEW_SHA; then
+              break
+            fi
+            sleep 5
+          done
           ./semantic-release \
             --allow-no-changes \
             --allow-initial-development-versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Package and push chart
         run: |
+          make sync-deployment-crds
           echo "${{ secrets.BOT_RELEASE_TOKEN }}" | helm registry login ghcr.io -u chantico-bot --password-stdin
           VERSION=${GITHUB_REF#refs/tags/v}
           helm package config/deployment/ --version $VERSION --app-version v$VERSION

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     rev: v1.0.0-rc.4
     hooks:
       - id: go-mod-tidy
-      - id: go-test-repo-mod
+      - id: go-test-mod
       - id: go-vet-mod
       - id: go-fmt
       - id: golangci-lint

--- a/config/deployment/templates/filebrowser.yaml
+++ b/config/deployment/templates/filebrowser.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: filebrowser
-        image: filebrowser/filebrowser:v2.32.2
+        image: docker.io/filebrowser/filebrowser:v2.32.2
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/deployment/templates/prometheus.yaml
+++ b/config/deployment/templates/prometheus.yaml
@@ -19,7 +19,7 @@ spec:
         runAsUser: 65534
         fsGroup: 1000
       containers:
-      - image: prom/prometheus:v3.7.3
+      - image: docker.io/prom/prometheus:v3.7.3
         name: prometheus
         command: ["prometheus"]
         args: ["--config.file=/tmp/prometheus-volume/yml/prometheus.yml", "--storage.tsdb.path=/tmp/prometheus-volume/storage", "--storage.tsdb.retention.time={{ .Values.prometheusRetention }}", "--web.enable-lifecycle", "--storage.tsdb.no-lockfile"]
@@ -38,7 +38,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       initContainers:
-      - image: busybox
+      - image: docker.io/library/busybox:1.36.1-glibc
         name: prometheus-initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/deployment/templates/snmp.yaml
+++ b/config/deployment/templates/snmp.yaml
@@ -18,7 +18,7 @@ spec:
       securityContext:
         fsGroup: 1000
       containers:
-      - image: ricardbejarano/snmp_exporter:0.26.0
+      - image: docker.io/ricardbejarano/snmp_exporter:0.26.0
         name: snmp
         volumeMounts:
         - mountPath: "/snmp.yml"
@@ -27,7 +27,7 @@ spec:
         ports:
         - containerPort: 9116
       initContainers:
-      - image: busybox
+      - image: docker.io/library/busybox:1.36.1-glibc
         name: structure-initialization
         command: ["/bin/sh"]
         args:

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -1,9 +1,9 @@
 package images
 
 const (
-	BusyBox       = "busybox:1.36.1-glibc"
-	SnmpGenerator = "prom/snmp-generator:v0.29.0"
-	SnmpExporter  = "ricardbejarano/snmp_exporter:0.26.0"
-	Filebrowser   = "filebrowser/filebrowser:v2.32.2"
-	Prometheus    = "prom/prometheus:v3.7.3"
+	BusyBox       = "docker.io/library/busybox:1.36.1-glibc"
+	SnmpGenerator = "docker.io/prom/snmp-generator:v0.29.0"
+	SnmpExporter  = "docker.io/ricardbejarano/snmp_exporter:0.26.0"
+	Filebrowser   = "docker.io/filebrowser/filebrowser:v2.32.2"
+	Prometheus    = "docker.io/prom/prometheus:v3.7.3"
 )


### PR DESCRIPTION
## Description

Reinstate solutions from GitLab CI for:
- synchronizing the deployment CRDs into the helm package
- releasing on the correct commit version

Also refer to the specific Docker Hub registry in the Helm images to avoid pull problems in some deployments.

## How to test

1. Checkout this branch.

2. Perform the steps of the release pipeline manually to package a Chantico helm chart, except for the helm login and push:
```bash
make sync-deployment-crds
VERSION=0.5.9 # example
helm package config/deployment/ --version $VERSION --app-version v$VERSION
```

3. Use the package to install in a Docker Desktop based kind cluster:

```bash
helm install chantico chantico-$VERSION.tgz -n chantico --create-namespace --set pvc.storageClassName=hostpath --kube-context docker-desktop
kubectl get pod -n chantico -w
```

4. Observe if all the pods get into running state.

## Linked issue

#121

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
