### PR TITLE
fix: Only run docker CI step from PR inside Chantico repo.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
 
   # Docker build and push
   docker:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: [test]
     steps:


### PR DESCRIPTION
## Description

Adds a check which makes sure the Docker CI step only runs from internal PRs or non PR pushes.

## How to test

Verify this PRs Docker step still succeeded. Also see this comment which presents the if statement: https://github.com/orgs/community/discussions/25217#discussioncomment-3246902

## Linked issue

#125 

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
