### PR TITLE
fix(ci): Create release for latest commit and only run on source repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
 
   # Start a release to create a new Git version
   release:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'chantico-project/chantico' && github.ref == 'refs/heads/main'
     needs: [test]
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,12 +289,13 @@ jobs:
           git config --global user.email "semantic-release@github"
           git config --global user.name "go-semantic-release"
           ./semantic-release --dry -f \
-            --changelog CHANGELOG.md \
-            --prepend-changelog \
+            --changelog CHANGELOG-unreleased.md \
             --allow-no-changes \
             --allow-initial-development-versions
           if [ ! -f .version-unreleased ]; then exit 0; fi
           VERSION=$(cat .version-unreleased)
+          cat CHANGELOG-unreleased.md CHANGELOG.md > CHANGELOG-temp.md
+          mv CHANGELOG-temp.md CHANGELOG.md
           # Commit updated versions in files if changed
           sed -E -i "s/^VERSION([ ?]*)=.*/VERSION\1= $VERSION/" Makefile
           sed -i "s/^version:.*/version: $VERSION/" config/deployment/Chart.yaml
@@ -306,15 +307,9 @@ jobs:
             git commit -m "bump version to v$VERSION [skip ci]"
             git push https://$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY HEAD:${GITHUB_REF_NAME}
           fi
-          NEW_SHA=$(git rev-parse HEAD)
-          for i in {1..20}; do
-            if git ls-remote https://$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY | grep $NEW_SHA; then
-              break
-            fi
-            sleep 5
-          done
-          ./semantic-release \
-            --allow-no-changes \
-            --allow-initial-development-versions
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push https://$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY "v$VERSION"
+          gh release create "v$VERSION" --repo $GITHUB_REPOSITORY --title "v$VERSION" --notes-file CHANGELOG-unreleased.md
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
 
   # Docker build and push
   docker:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.repository == 'chantico-project/chantico' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     needs: [test]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     continue-on-error: true
+    if: github.repository == 'chantico-project/chantico'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -35,6 +36,7 @@ jobs:
   # Helm release
   helm:
     runs-on: ubuntu-latest
+    if: github.repository == 'chantico-project/chantico'
 
     steps:
       - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ osv-scanner-report*.json
 .semrel/
 semantic-release
 .version*
+CHANGELOG-*.md
 # Added by goreleaser init:
 dist/
 


### PR DESCRIPTION
## Description

There were still a few issues from our migration to GitHub affecting the CI for external contributors and the release flow:

- Forks would still run steps to push to GHCR and (on main branch) perform a release, which fails due to missing Service Account tokens or access rights to the registry, due to our naming convention to separate images and charts.
- During the release step of the CI workflow, the second semantic-release call would not always find the most recent commit pushed to GitHub, namely the one where the changelog is updated and versions are changed in some files, like the chart metadata. This would cause confusion to external users that find different version numbers in the release information and in the files/deployments themselves.

## How to test

I created a fork, added chantico-bot as collaborator and set up a token for the bot with `repo` and `write:packages` scopes. However, as the GHCR image registry names are not scoped to the repository itself and the access control is only set up afterward, this is not enough to allow the bot to push Docker images so this still needs to be skipped. It is now is correctly skipped for forks. I also tested that the release can be created (before adding the `if` for the release steps) by merging this branch on the fork, and that it refers to the commit it just created with all the semantic changelog information as well.

## Linked issue

#130 

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
