### PR TITLE
fix(ci): Extract reusable Docker workflow to run on release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,55 +75,14 @@ jobs:
             report.json
             coverage.xml
 
-  # Docker build and push
-  docker:
-    if: github.repository == 'chantico-project/chantico' &&
-      (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set tags
-        id: meta
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "controller=images/chantico" >> $GITHUB_OUTPUT
-            echo "snmp=images/chantico-snmp-mock" >> $GITHUB_OUTPUT
-            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            echo "controller=images/chantico-pr" >> $GITHUB_OUTPUT
-            echo "snmp=images/chantico-snmp-mock-pr" >> $GITHUB_OUTPUT
-            echo "tag=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
-          else
-            echo "controller=images/chantico" >> $GITHUB_OUTPUT
-            echo "snmp=images/chantico-snmp-mock" >> $GITHUB_OUTPUT
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: chantico-bot
-          password: ${{ secrets.BOT_RELEASE_TOKEN }}
-
-      - name: Build and push chantico controller
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ steps.meta.outputs.controller }}:${{ steps.meta.outputs.tag }}
-
-      - name: Build and push snmp-mock
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile.snmp-mock
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ steps.meta.outputs.snmp }}:${{ steps.meta.outputs.tag }}
+  invoke-docker:
+    if: github.repository == 'chantico-project/chantico' && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
+    needs: test
+    uses: ./.github/workflows/docker.yml
+    with:
+      ref: ${{ github.ref }}
+      pr: ${{ github.event.pull_request.number }}
+    secrets: inherit
 
   # Documentation build
   docs:
@@ -327,4 +286,12 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ needs.release.outputs.version }}
+    secrets: inherit
+
+  invoke-docker-tag:
+    if: github.repository == 'chantico-project/chantico' && needs.release.outputs.version != ''
+    needs: invoke-release
+    uses: ./.github/workflows/docker.yml
+    with:
+      ref: refs/tags/v${{ needs.release.outputs.version }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,5 +293,6 @@ jobs:
     needs: release
     uses: ./.github/workflows/docker.yml
     with:
+      ref: refs/tags/v${{ needs.release.outputs.version }}
       version: ${{ needs.release.outputs.version }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,10 +288,10 @@ jobs:
       version: ${{ needs.release.outputs.version }}
     secrets: inherit
 
-  invoke-docker-tag:
+  invoke-docker-release:
     if: github.repository == 'chantico-project/chantico' && needs.release.outputs.version != ''
-    needs: invoke-release
+    needs: release
     uses: ./.github/workflows/docker.yml
     with:
-      ref: refs/tags/v${{ needs.release.outputs.version }}
+      version: ${{ needs.release.outputs.version }}
     secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       ref:
         required: true
         type: string
-      tag:
+      version:
         required: false
         type: string
       pr:
@@ -32,14 +32,14 @@ jobs:
       - name: Set tags
         id: meta
         run: |
-          if [ ! -z "${{ inputs.tag }}" ]; then
+          if [ ! -z "${{ inputs.version }}" ]; then
             echo "controller=images/chantico" >> $GITHUB_OUTPUT
             echo "snmp=images/chantico-snmp-mock" >> $GITHUB_OUTPUT
-            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "tag=v${{ inputs.version }}" >> $GITHUB_OUTPUT
           elif [ ! -z "${{ inputs.pr }}" ]; then
             echo "controller=images/chantico-pr" >> $GITHUB_OUTPUT
             echo "snmp=images/chantico-snmp-mock-pr" >> $GITHUB_OUTPUT
-            echo "tag=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+            echo "tag=pr-${{ inputs.pr }}" >> $GITHUB_OUTPUT
           else
             echo "controller=images/chantico" >> $GITHUB_OUTPUT
             echo "snmp=images/chantico-snmp-mock" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,70 @@
+name: Docker build and push
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      tag:
+        required: false
+        type: string
+      pr:
+        required: false
+        type: number
+
+permissions:
+  contents: write
+  packages: write
+  pages: write
+  id-token: write
+
+jobs:
+  # Docker build and push
+  docker:
+    if: github.repository == 'chantico-project/chantico'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set tags
+        id: meta
+        run: |
+          if [ ! -z "${{ inputs.tag }}" ]; then
+            echo "controller=images/chantico" >> $GITHUB_OUTPUT
+            echo "snmp=images/chantico-snmp-mock" >> $GITHUB_OUTPUT
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          elif [ ! -z "${{ inputs.pr }}" ]; then
+            echo "controller=images/chantico-pr" >> $GITHUB_OUTPUT
+            echo "snmp=images/chantico-snmp-mock-pr" >> $GITHUB_OUTPUT
+            echo "tag=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "controller=images/chantico" >> $GITHUB_OUTPUT
+            echo "snmp=images/chantico-snmp-mock" >> $GITHUB_OUTPUT
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: chantico-bot
+          password: ${{ secrets.BOT_RELEASE_TOKEN }}
+
+      - name: Build and push chantico controller
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ steps.meta.outputs.controller }}:${{ steps.meta.outputs.tag }}
+
+      - name: Build and push snmp-mock
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.snmp-mock
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ steps.meta.outputs.snmp }}:${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Description

Perform Docker workflow when a commit is made on main or in a PR from the source repository, and now also again after a release is created, to push tagged Docker images to the registry.

## How to test

View [PR image registry](https://github.com/chantico-project/chantico/pkgs/container/images%2Fchantico-pr) to verify if the docker image is pushed from this PR. Review the changes to validate that something similar should happen from a release.

## Linked issue

Closes #132 

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
