### PR TITLE
Document storage class override

### DIFF
--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -5,8 +5,13 @@ set -ex
 SCRIPT_DIR=$(dirname -- "$( readlink -f -- "$0"; )")
 SNMP_MOCK_TAG="${SNMP_MOCK_TAG:-latest}"
 
-# get kind
-go install sigs.k8s.io/kind@v0.30.0
+# get kind if not already installed
+if which kind; then
+	echo "Using installed kind: $(which kind)"
+else
+	echo "Installing kind"
+	go install sigs.k8s.io/kind@v0.30.0
+fi
 
 # If go is not yet added to $PATH:
 #echo 'export PATH="$(go env GOPATH)/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc

--- a/docs/how-tos/how-to-install-chantico.md
+++ b/docs/how-tos/how-to-install-chantico.md
@@ -11,7 +11,7 @@ menus:
 The easiest option to install Chantico into your k8s cluster is by using the helm package from the OCI Registry.
 
 ```bash
-helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico # Latest version
+helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico --create-namespace # Latest version
 ```
 
 - The command above installs the latest version of Chantico. See available [chart versions](https://github.com/chantico-project/chantico/pkgs/container/charts%2Fchantico). Also check out the [releases](https://github.com/chantico-project/chantico/releases) or the [changelog](/technical/changelog.md) on the documentation website for the list of changes throughout the version history.
@@ -24,6 +24,23 @@ To upgrade an existing chantico deployment to a new version, run `helm upgrade` 
 
 ```bash
 helm upgrade chantico oci://ghcr.io/chantico-project/charts/chantico --version <version> -n chantico
+```
+
+## Using an alternative storage class
+
+The Chantico chart create a persistent volume claim to store Prometheus data.
+By default, the Chantico chart uses the `csi-rbd` storage class.
+As a user, you might want to use a different storage class.
+This can be done by overriding the `pvc.storageClassName` value when installing or upgrading Chantico.
+
+```bash
+helm install chantico oci://ghcr.io/chantico-project/charts/chantico -n chantico --create-namespace --set pvc.storageClassName="STORAGE_CLASS_NAME"
+```
+
+You can list the storage classes available on your cluster with kubectl.
+
+```bash
+kubectl get storageclass
 ```
 
 ## Getting started with the deployed Chantico


### PR DESCRIPTION
## Description

Only install kind when it is not already installed, and add instructions for alternative storage class settings.

## How to test
Run `dev/install.sh` and see that it does not automatically install kind anymore.
Read the documentation and try to use a different storageclass (like `local-path`).


## Linked issue
#120 


## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- `N/A` Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
