### PR TITLE
New dev targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,18 @@ lint: golangci-lint ## Run golangci-lint linter
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
+.PHONY: setup-kind
+setup-kind: ./dev/setup.sh ## Setup kind cluster for local deployment
+	./dev/setup.sh
+
+.PHONY: port-forward
+port-forward: ./dev/port-forward.sh ## Forward ports from local kind deployment
+	./dev/port-forward.sh
+
+.PHONY: teardown-kind
+teardown-kind: ./dev/teardown.sh ## Tear down kind cluster to clean up local deployment
+	./dev/teardown.sh
+
 ##@ Build
 
 .PHONY: build

--- a/docs/how-tos/how-to-setup-the-local-development-environment.md
+++ b/docs/how-tos/how-to-setup-the-local-development-environment.md
@@ -24,13 +24,13 @@ It requires the following packages:
 - To install the kind docker cluster, run:
 
   ```bash
-  ./dev/setup.sh
+  make setup-kind
   ```
 
 - In a separate terminal, setup the port forward:
 
   ```bash
-  ./dev/port-forward.sh
+  make port-forward
   ```
   
   Redo this command whenever you end it to help developing.
@@ -59,8 +59,8 @@ After setting up the local development environment, you are ready to run the dem
 
 ### Teardown
 
-To teardown a local installation of the kind cluster, run the script:
+To teardown a local installation of the kind cluster, run the following:
 
 ```bash
-./dev/teardown.sh
+make teardown-kind
 ```


### PR DESCRIPTION
## Description
Add the `kind-setup`, `kind-teardown`, and `port-forward` targets for local deployment of chantico. Idea from [this comment](https://github.com/chantico-project/chantico/pull/136#pullrequestreview-4427751014).


## How to test
Run `make setup-kind`, `make port-forward`, `make teardown-kind`, and `make help`.


## Linked issue
https://github.com/chantico-project/chantico/pull/136#pullrequestreview-4427751014


## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [ ] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
