### PR TITLE
fix: Prometheus reloading fails after configuring a DataCenterResource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
       - id: go-test-mod
       - id: go-vet-mod
       - id: go-fmt
-      - id: golangci-lint
+      - id: golangci-lint-pkg

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -222,4 +222,4 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
+	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/cluster-api v1.13.1
 	sigs.k8s.io/controller-runtime v0.23.3
 )
@@ -96,7 +97,6 @@ require (
 	k8s.io/component-base v0.35.4 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260330154417-16be699c7b31 // indirect
-	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"time"
 )
 
 const (
@@ -13,6 +14,7 @@ const (
 	ChanticoVolumeClaimEnv           = "CHANTICOVOLUMECLAIMENV"
 	ChanticoPrometheusServiceHostEnv = "CHANTICO_PROMETHEUS_SERVICE_HOST"
 	ChanticoPrometheusServicePortEnv = "CHANTICO_PROMETHEUS_SERVICE_PORT"
+	ValidateHostPortTimeout          = 5 * time.Second
 )
 
 type validatedEnv struct {
@@ -59,10 +61,9 @@ func ValidateEnv() (validatedEnv, []error) {
 		err = validateHostPort(prometheusServiceHost, prometheusServicePort)
 		if err != nil {
 			errs = append(errs, err)
+			ret.PrometheusServiceHost = ""
+			ret.PrometheusServicePort = ""
 		}
-		ret.PrometheusServiceHost = ""
-		ret.PrometheusServicePort = ""
-
 	}
 	if len(errs) > 0 {
 		return ret, errs
@@ -72,11 +73,14 @@ func ValidateEnv() (validatedEnv, []error) {
 }
 
 func validateHostPort(host, port string) error {
-	conn, err := net.Dial("tcp", net.JoinHostPort(host, port))
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), ValidateHostPortTimeout)
 	if err != nil {
-		return fmt.Errorf("cannot connect to host '%s': %w. If this is a development environment, make sure port forwarding has started.", net.JoinHostPort(host, port), err)
+		return fmt.Errorf("cannot connect to host '%s': %w. If this is a development environment, make sure port forwarding has started", net.JoinHostPort(host, port), err)
 	} else {
-		conn.Close()
+		err = conn.Close()
+		if err != nil {
+			return fmt.Errorf("error closing connection to host '%s': %w", net.JoinHostPort(host, port), err)
+		}
 		return nil
 	}
 }

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -50,7 +50,7 @@ func testUnsetBadEnv(t *testing.T, env string, val string, tester func(validated
 func testIdentity(env validatedEnv) bool { return true }
 
 func TestUnsetVar(t *testing.T) {
-	os.Unsetenv(ChanticoVolumeClaimEnv)
+	_ = os.Unsetenv(ChanticoVolumeClaimEnv)
 	testUnsetBadEnv(t, ChanticoVolumeClaimEnv, "[UNSET]", testIdentity)
 }
 
@@ -62,15 +62,15 @@ func TestEmptyVars(t *testing.T) {
 func TestAllVarsOkay(t *testing.T) {
 	const goodClaim = "test-test-test"
 	var goodLocation = os.Getenv("PWD")
-	const goodUrl = "example.com"
-	const goodPort = "80"
+	const goodUrl = "github.com"
+	const goodPort = "443"
 
 	t.Parallel() // This test cannot run in parallel with the others, because the environment variables may interfere
 
-	os.Setenv(ChanticoVolumeClaimEnv, goodClaim)
-	os.Setenv(ChanticoVolumeLocationEnv, goodLocation)
-	os.Setenv(ChanticoPrometheusServiceHostEnv, goodUrl)
-	os.Setenv(ChanticoPrometheusServicePortEnv, goodPort)
+	_ = os.Setenv(ChanticoVolumeClaimEnv, goodClaim)
+	_ = os.Setenv(ChanticoVolumeLocationEnv, goodLocation)
+	_ = os.Setenv(ChanticoPrometheusServiceHostEnv, goodUrl)
+	_ = os.Setenv(ChanticoPrometheusServicePortEnv, goodPort)
 
 	_, errs := ValidateEnv()
 
@@ -102,14 +102,17 @@ func TestVolumeIsDir(t *testing.T) {
 	if err != nil {
 		t.Error("Error creating temporary file, this should not happen")
 	}
-	defer os.Remove(file.Name())
+	defer func() {
+		_ = os.Remove(file.Name())
+	}()
 
 	var fileName = file.Name()
 	testBadEnv(t, ChanticoVolumeLocationEnv, fileName, testIdentity)
 }
 
 func TestParseNetwork(t *testing.T) {
-	const goodUrl = "example.com"
+	const goodUrl = "github.com"
+	t.Setenv(ChanticoPrometheusServicePortEnv, "443")
 	var testGoodUrl = func(env validatedEnv) bool { return env.PrometheusServiceHost == goodUrl }
 	testGoodEnv(t, ChanticoPrometheusServiceHostEnv, goodUrl, testGoodUrl)
 
@@ -129,8 +132,8 @@ func TestParseNetwork(t *testing.T) {
 func TestBadHostPort(t *testing.T) {
 	const goodUrl = "localhost"
 	const reservedPort = "2" // Port 2 is reserved by the IANA (iana.org). Should be unused on all computer environments
-	os.Setenv(ChanticoPrometheusServiceHostEnv, goodUrl)
-	os.Setenv(ChanticoPrometheusServicePortEnv, reservedPort)
+	t.Setenv(ChanticoPrometheusServiceHostEnv, goodUrl)
+	t.Setenv(ChanticoPrometheusServicePortEnv, reservedPort)
 
 	ValidatedEnv, errs := ValidateEnv()
 
@@ -153,11 +156,14 @@ func TestBadHostPort(t *testing.T) {
 }
 
 func TestGoodHostPort(t *testing.T) {
-	const goodUrl = "example.com"
-	const goodPort = "80"
+	const goodUrl = "github.com"
+	const goodPort = "443"
 
-	os.Setenv(ChanticoPrometheusServiceHostEnv, goodUrl)
-	os.Setenv(ChanticoPrometheusServicePortEnv, goodPort)
+	t.Setenv(ChanticoPrometheusServiceHostEnv, goodUrl)
+	t.Setenv(ChanticoPrometheusServicePortEnv, goodPort)
 
-	testGoodEnv(t, ChanticoPrometheusServiceHostEnv, goodUrl, testIdentity)
+	var testGoodHostPort = func(env validatedEnv) bool {
+		return env.PrometheusServiceHost == goodUrl && env.PrometheusServicePort == goodPort
+	}
+	testGoodEnv(t, ChanticoPrometheusServiceHostEnv, goodUrl, testGoodHostPort)
 }


### PR DESCRIPTION
## Description

Due to an unconditional clear of the prometheus host and port during configuration validation, the reload would not function properly.

- Do not clear host and port in configuration if they are valid
- Add a timeout to the host/port check to avoid blocking forever
- Improve tests
- Update golangci-lint to v2.12.2 and fix some lint checks

## How to test

- Option 1: Run tests locally with `make test`
- Option 2: Deploy in cluster with `helm upgrade chantico oci://ghcr.io/chantico-project/charts/chantico --version 0.6.3 --set controller.image.repository=ghcr.io/chantico-project/images/chantico-pr --set controller.image.tag=pr-149 -n chantico`, following the usual documentation for production-like deployment

## Linked issue

Closes #148 

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
