### PR TITLE
fix(ci): Update documentation website upon release via reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,148 +84,11 @@ jobs:
       pr: ${{ github.event.pull_request.number }}
     secrets: inherit
 
-  # Documentation build
-  docs:
-    runs-on: ubuntu-latest
-    #if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Generate docs
-        run: |
-          go install go.abhg.dev/doc2go@v0.11.0
-
-          REL_LINK_STYLE=index
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            REL_LINK_STYLE=directory
-          fi
-
-          doc2go -embed -highlight classes:monokai \
-            -basename _index.html \
-            -out docs/technical/api \
-            -frontmatter docs/hugo/frontmatter.tmpl \
-            -rel-link-style $REL_LINK_STYLE \
-            -internal ./...
-
-          find docs/technical/api -type f -name '*.html' -print0 | xargs -0 sed -i 's/_index\.html/index.html/g'
-          printf -- "---\ntitle: "Changelog"\nweight: 60\nmain:\n  parent: technical\n  weight: 50\n---\n%s" "$(sed -E -e "s|\(([0-9a-f]{7,})\)|([\1](https://github.com/$GITHUB_REPOSITORY/commit/\1))|" -e "s|^## ([0-9]+\.[0-9]+\.[0-9]+)|## [\1](https://github.com/$GITHUB_REPOSITORY/releases/tag/v\1)|" CHANGELOG.md)" > docs/technical/changelog.md
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: docs
-          path: docs
-
-  # Documentation preview artifact
-  preview:
-    if: github.event_name == 'pull_request'
-    needs: docs
-    runs-on: ubuntu-latest
-    container:
-      image: hugomods/hugo:debian-exts
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: docs
-          path: docs
-
-      - name: Build preview
-        run: |
-          cd docs/hugo
-          hugo --baseURL="/" --config "hugo.toml,hugo.preview.toml"
-
-      - name: Upload preview artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: hugo-preview
-          path: docs/hugo/public
-
-  # Check links in documentation preview
-  docs-check-links:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    needs: preview
-    continue-on-error: true
-
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: hugo-preview
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Start local server
-        run: |
-          cat <<'EOF' > server.go
-          package main
-          import (
-            "log"
-            "net/http"
-          )
-          func main() {
-            log.Println("Serving on :8000")
-            log.Fatal(http.ListenAndServe(":8000", http.FileServer(http.Dir("."))))
-          }
-          EOF
-
-          go run server.go &
-          echo $! > server.pid
-
-      - name: Install muffet
-        run: go install github.com/raviqqe/muffet/v2@v2.11.2
-
-      - name: Run link checker
-        run: |
-          muffet --verbose --include="http://localhost:8000" http://localhost:8000/index.html
-
-      - name: Stop server
-        if: always()
-        run: kill $(cat server.pid)
-
-  # Deployment of documentation to GitHub Pages
-  pages:
-    if: github.ref == 'refs/heads/main'
-    needs: docs
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    container:
-      image: hugomods/hugo:debian-exts
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: docs
-          path: docs
-
-      - name: Build site
-        run: |
-          cd docs/hugo
-          hugo --baseURL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
-
-      - uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs/hugo/public
-
-      - id: deploy
-        uses: actions/deploy-pages@v5
-
-    env:
-      CI_COMMIT_BRANCH: ${{ github.head_ref }}
+  invoke-docs:
+    uses: ./.github/workflows/docs.yml
+    with:
+      ref: ${{ github.ref }}
+    secrets: inherit
 
   # Start a release to create a new Git version
   release:
@@ -295,4 +158,12 @@ jobs:
     with:
       ref: refs/tags/v${{ needs.release.outputs.version }}
       version: ${{ needs.release.outputs.version }}
+    secrets: inherit
+
+  invoke-docs-release:
+    if: needs.release.outputs.version != ''
+    needs: release
+    uses: ./.github/workflows/docs.yml
+    with:
+      ref: refs/tags/v${{ needs.release.outputs.version }}
     secrets: inherit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+env:
+  GO_VERSION: "1.25"
+
 jobs:
   # Documentation build
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,151 @@
+name: Documentation
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+jobs:
+  # Documentation build
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Generate docs
+        run: |
+          go install go.abhg.dev/doc2go@v0.11.0
+
+          REL_LINK_STYLE=index
+          if [[ "${{ inputs.ref }}" == "main" ]]; then
+            REL_LINK_STYLE=directory
+          fi
+
+          doc2go -embed -highlight classes:monokai \
+            -basename _index.html \
+            -out docs/technical/api \
+            -frontmatter docs/hugo/frontmatter.tmpl \
+            -rel-link-style $REL_LINK_STYLE \
+            -internal ./...
+
+          find docs/technical/api -type f -name '*.html' -print0 | xargs -0 sed -i 's/_index\.html/index.html/g'
+          printf -- "---\ntitle: "Changelog"\nweight: 60\nmain:\n  parent: technical\n  weight: 50\n---\n%s" "$(sed -E -e "s|\(([0-9a-f]{7,})\)|([\1](https://github.com/$GITHUB_REPOSITORY/commit/\1))|" -e "s|^## ([0-9]+\.[0-9]+\.[0-9]+)|## [\1](https://github.com/$GITHUB_REPOSITORY/releases/tag/v\1)|" -e "s|\(#([1-9][0-9]+)\)|([#\1](https://github.com/$GITHUB_REPOSITORY/issues/\1))|" CHANGELOG.md)" > docs/technical/changelog.md
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: docs
+          path: docs
+
+  # Documentation preview artifact
+  preview:
+    if: inputs.ref != 'refs/heads/main' && !startsWith(inputs.ref, 'refs/tags/v')
+    needs: docs
+    runs-on: ubuntu-latest
+    container:
+      image: hugomods/hugo:debian-exts
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: docs
+          path: docs
+
+      - name: Build preview
+        run: |
+          cd docs/hugo
+          hugo --baseURL="/" --config "hugo.toml,hugo.preview.toml"
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: hugo-preview
+          path: docs/hugo/public
+
+  # Check links in documentation preview
+  docs-check-links:
+    if: inputs.ref != 'refs/heads/main' && !startsWith(inputs.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: preview
+    continue-on-error: true
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: hugo-preview
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Start local server
+        run: |
+          cat <<'EOF' > server.go
+          package main
+          import (
+            "log"
+            "net/http"
+          )
+          func main() {
+            log.Println("Serving on :8000")
+            log.Fatal(http.ListenAndServe(":8000", http.FileServer(http.Dir("."))))
+          }
+          EOF
+
+          go run server.go &
+          echo $! > server.pid
+
+      - name: Install muffet
+        run: go install github.com/raviqqe/muffet/v2@v2.11.2
+
+      - name: Run link checker
+        run: |
+          muffet --verbose --include="http://localhost:8000" http://localhost:8000/index.html
+
+      - name: Stop server
+        if: always()
+        run: kill $(cat server.pid)
+
+  # Deployment of documentation to GitHub Pages
+  pages:
+    if: inputs.ref == 'refs/heads/main' || startsWith(inputs.ref, 'refs/tags/v')
+    needs: docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    container:
+      image: hugomods/hugo:debian-exts
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: recursive
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: docs
+          path: docs
+
+      - name: Build site
+        run: |
+          cd docs/hugo
+          hugo --baseURL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs/hugo/public
+
+      - id: deploy
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
     continue-on-error: true
     if: github.repository == 'chantico-project/chantico'
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-v${{ inputs.version }}
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: v${{ inputs.version }}
+          ref: refs/tags/v${{ inputs.version }}
           fetch-depth: 0
 
       - name: Run GoReleaser
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: v${{ inputs.version }}
+          ref: refs/tags/v${{ inputs.version }}
 
       - name: Setup Helm
         uses: azure/setup-helm@v5


### PR DESCRIPTION


## Description

When the semantic release triggers creation and push of a tag, call a reusable workflow to build and publish the documentation website to GitHub Pages to keep the changelog page in sync with the latest released version.

It is good to have a synchronized experience of having the latest release changelog in all places. This is also good in case we ever make the documentation available for multiple versions (for example, latest main branch and one or more/all tagged releases).

Also link the issue numbers from commit messages to GitHub issues.

## How to test

Because it is a release pipeline, this can only be tested thoroughly by creating a fork, merging the branch there to main and witnessing a GitHub Pages deployment with the latest semantic commit message represented on the changelog page in the technical reference section.

For the issue number linking, you can download the built 'hugo-preview' artifact from the "Checks" tab, extract it and host it on a local server (`python3 -m http.server 8080` or similar) to see how the changelog page would look.

## Linked issue

Closes #151 

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
