### PR TITLE
Build helm chart for Pull Requests and perform helm lint in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# Main CI workflow using reusable workflows
 name: CI
 
 on:
@@ -84,6 +85,15 @@ jobs:
       pr: ${{ github.event.pull_request.number }}
     secrets: inherit
 
+  invoke-helm:
+    if: github.event_name == 'pull_request'
+    needs: test
+    uses: ./.github/workflows/helm.yml
+    with:
+      ref: ${{ github.ref }}
+      pr: ${{ github.event.pull_request.number }}
+    secrets: inherit
+
   invoke-docs:
     uses: ./.github/workflows/docs.yml
     with:
@@ -155,6 +165,15 @@ jobs:
     if: github.repository == 'chantico-project/chantico' && needs.release.outputs.version != ''
     needs: release
     uses: ./.github/workflows/docker.yml
+    with:
+      ref: refs/tags/v${{ needs.release.outputs.version }}
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit
+
+  invoke-helm-release:
+    if: github.repository == 'chantico-project/chantico' && needs.release.outputs.version != ''
+    needs: release
+    uses: ./.github/workflows/helm.yml
     with:
       ref: refs/tags/v${{ needs.release.outputs.version }}
       version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,61 @@
+name: Helm package and push
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      version:
+        required: false
+        type: string
+      pr:
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+  pages: write
+  id-token: write
+
+jobs:
+  # Helm release
+  helm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set tags
+        id: meta
+        run: |
+          if [ ! -z "${{ inputs.version }}" ]; then
+            echo "registry=charts" >> $GITHUB_OUTPUT
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          elif [ ! -z "${{ inputs.pr }}" ]; then
+            echo "registry=charts-pr" >> $GITHUB_OUTPUT
+            echo "version=pr-${{ inputs.pr }}" >> $GITHUB_OUTPUT
+          else
+            echo "registry=charts" >> $GITHUB_OUTPUT
+            echo "version=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v5
+
+      - name: Package and lint chart
+        id: package
+        run: |
+          make sync-deployment-crds
+          helm lint chart/
+          helm package chart/ --version ${{ steps.meta.outputs.version }} --destination dist
+          echo "chart=$(ls -1 dist/chantico-*.tgz)" >> $GITHUB_OUTPUT
+
+      - name: Push chart to GHCR
+        if: github.repository == 'chantico-project/chantico'
+        run: |
+          echo "${{ secrets.BOT_RELEASE_TOKEN }}" | helm registry login ghcr.io -u chantico-bot --password-stdin
+          helm push "${{ steps.package.outputs.chart }}" oci://ghcr.io/${{ github.repository_owner }}/${{ steps.meta.outputs.registry }}

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -36,11 +36,12 @@ jobs:
             echo "registry=charts" >> $GITHUB_OUTPUT
             echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
           elif [ ! -z "${{ inputs.pr }}" ]; then
+            VERSION=$(helm show chart chart/ | sed -nE 's/^version: *//p')
             echo "registry=charts-pr" >> $GITHUB_OUTPUT
-            echo "version=pr-${{ inputs.pr }}" >> $GITHUB_OUTPUT
+            echo "version=$VERSION-pr-${{ inputs.pr }}" >> $GITHUB_OUTPUT
           else
-            echo "registry=charts" >> $GITHUB_OUTPUT
-            echo "version=latest" >> $GITHUB_OUTPUT
+            echo "One of 'version' or 'pr' input parameters must be provided." >&2
+            exit 1
           fi
 
       - name: Setup Helm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,24 +37,3 @@ jobs:
           args: release --config .goreleaser.github.yaml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}
-
-  # Helm release
-  helm:
-    runs-on: ubuntu-latest
-    if: github.repository == 'chantico-project/chantico'
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: refs/tags/v${{ inputs.version }}
-
-      - name: Setup Helm
-        uses: azure/setup-helm@v5
-
-      - name: Package and push chart
-        run: |
-          make sync-deployment-crds
-          echo "${{ secrets.BOT_RELEASE_TOKEN }}" | helm registry login ghcr.io -u chantico-bot --password-stdin
-          VERSION=${{ inputs.version }}
-          helm package chart/ --version $VERSION --app-version v$VERSION
-          helm push chantico-*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts


### PR DESCRIPTION
## Description

- Changes to helm package structure can be deployed in non-local environments during testing by using a PR registry with the PR number as version
- We check if the helm structure is correct with `helm lint` in the CI

## How to test

1. Check if this PR is successful in pushing a Helm image with PR version to the [charts-pr/chantico](https://github.com/orgs/chantico-project/packages/container/package/charts-pr%2Fchantico) registry (naming is this way around instead of charts/chantico-pr as helm does not allow overriding the name and mutating the YAML during publishing seems hacky)
2. Pull the helm chart for deployment `helm upgrade chantico oci://ghcr.io/chantico-project/charts-pr/chantico --version 0.6.3-pr-167 --set controller.image.repository=ghcr.io/chantico-project/images/chantico-pr --set controller.image.tag=pr-167 -n chantico`

## Linked issue

- Closes #162 
- Closes #156 

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [ ] The new changes are reflected into the documentation.
