### PR TITLE
feat: Track prometheus scraping interval and add panel on timeliness

### DIFF
--- a/chart/dashboards/datacenter-overview.json
+++ b/chart/dashboards/datacenter-overview.json
@@ -15,6 +15,10 @@
       }
     ]
   },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2,
   "links": [],
   "panels": [
     {
@@ -32,7 +36,7 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 16,
+        "w": 13,
         "x": 0,
         "y": 0
       },
@@ -42,6 +46,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -82,7 +87,7 @@
       "gridPos": {
         "h": 5,
         "w": 8,
-        "x": 16,
+        "x": 13,
         "y": 0
       },
       "id": 2,
@@ -91,6 +96,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -112,6 +118,127 @@
         }
       ],
       "title": "Total power (all PDUs)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "chantico-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "mappings": [
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "On time"
+                },
+                "to": 10
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 10,
+                "result": {
+                  "color": "light-green",
+                  "index": 1,
+                  "text": "OK"
+                },
+                "to": 10.5
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 10.5,
+                "result": {
+                  "color": "yellow",
+                  "index": 2,
+                  "text": "Late"
+                },
+                "to": 11
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 11,
+                "result": {
+                  "color": "red",
+                  "index": 3,
+                  "text": "Slow"
+                },
+                "to": 60
+              },
+              "type": "range"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 10.5
+              },
+              {
+                "color": "red",
+                "value": 11
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 21,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "prometheus_target_interval_length_seconds{interval=\"10s\", quantile=\"0.9\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Scraping interval",
       "type": "stat"
     },
     {
@@ -307,5 +434,6 @@
   "timezone": "",
   "title": "Datacenter overview",
   "uid": "chantico-overview",
+  "version": 1,
   "weekStart": ""
 }

--- a/chart/dashboards/datacenter-overview.json
+++ b/chart/dashboards/datacenter-overview.json
@@ -151,7 +151,7 @@
                   "index": 1,
                   "text": "OK"
                 },
-                "to": 10.5
+                "to": 10.08
               },
               "type": "range"
             },
@@ -186,14 +186,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 10.5
-              },
-              {
-                "color": "red",
-                "value": 11
               }
             ]
           }
@@ -228,8 +220,8 @@
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "prometheus_target_interval_length_seconds{interval=\"10s\", quantile=\"0.9\"}",
+          "editorMode": "code",
+          "expr": "prometheus_target_interval_length_seconds{interval=\"10s\", quantile=\"0.99\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -73,6 +73,9 @@ spec:
               - url: http://chantico-victoriametrics:8428/api/v1/write
             {{- end }}
             scrape_configs:
+              - job_name: prometheus
+                static_configs:
+                  - targets: ['localhost:9090']
               - job_name: snmp
                 file_sd_configs:
                   - files:


### PR DESCRIPTION
## Description

In order to reasonably have metrics at each wall clock minute (xx:00), we can do several things to ensure this:

- Perform manual metrics at exact moments from a hefty RT-kernel based machine (increases requirements that we do not control)
- Collect enough metrics around the exact moment to perform interpolation (increase scrape interval at cost of more performance overhead of our monitoring system)
- Collect metrics as we do now but monitor that the scraping interval does not diverge too much from the plan.

This encompasses some of the "collect enough metrics to perform interpolation" which is already implemented in VictoriaMetrics (using a 1-minute downsampling interval strategy) but focused on the "monitor scrape interval" aspect to ensure these metrics remain available. Prometheus tracks its health internally and these metrics can also be exported to it again, so that they can be queried by alerting/monitoring setups. As a proof of concept, this adds a panel to the dashboard indicating if the scrape interval is within acceptable parameters (90th quantile should be at most 10.x where x is a low decimal such that it rounds to 10 seconds, especially across 6 scraped per minute, so at most 10.083... or thereabout). Realistically, prometheus should be near 10.001 for this metric even on less performant dev setups, so it is unlikely that the threshold would be reached.

## How to test

1. Deploy as usual (`make cluster-up`, `make cluster-configure`, `make cluster-mibs`)
2. Apply a mock measurement device to perform scraping
3. At http://localhost:19090/query perform the query `prometheus_target_interval_length_seconds{interval="10s", quantile="0.99"}` to view current scrape interval at 99th percentile
4. Visit the dashboard at http://localhost:13000/d/chantico-overview/datacenter-overview to view the added scrape interval panel, indicating OK or better


## Linked issue

Closes #97

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
