### PR TITLE
chore: Update sigrid configuration to track components from internal directory again

### DIFF
--- a/.github/workflows/sigrid-publish.yml
+++ b/.github/workflows/sigrid-publish.yml
@@ -18,5 +18,6 @@ jobs:
           customer: tno
           system: chantico
           publishonly: true
+          capability: maintainability,osh,security
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Upload Sigrid CI output as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: sigridci-ci-output
-          path: sigridci-ci-output/
+          name: sigrid-ci-output
+          path: sigrid-ci-output/
           if-no-files-found: warn

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -21,3 +21,9 @@ jobs:
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
           SIGRIDCI_GITHUB_COMMENT_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Upload Sigrid CI report as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sigridci-ci-output
+          path: sigridci-ci-output/
+          if-no-files-found: warn

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           customer: tno
           system: chantico
+          capability: maintainability,osh,security
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
           SIGRIDCI_GITHUB_COMMENT_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -21,8 +21,8 @@ jobs:
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
           SIGRIDCI_GITHUB_COMMENT_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Upload Sigrid CI report as artifact
-        uses: actions/upload-artifact@v3
+      - name: Upload Sigrid CI output as artifact
+        uses: actions/upload-artifact@v7
         with:
           name: sigridci-ci-output
           path: sigridci-ci-output/

--- a/internal/controller/measurementdevice_controller.go
+++ b/internal/controller/measurementdevice_controller.go
@@ -44,7 +44,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	util "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -118,7 +117,7 @@ func (r *MeasurementDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 func (r *MeasurementDeviceReconciler) reconcileDeletion(ctx context.Context, measurementDevice *chantico.MeasurementDevice) steps.StepResult {
-	if measurementDevice.ObjectMeta.GetDeletionTimestamp() == nil {
+	if measurementDevice.GetDeletionTimestamp() == nil {
 		return steps.Continue()
 	}
 
@@ -233,7 +232,7 @@ func (r *MeasurementDeviceReconciler) createGeneratorJob(
 	if err != nil {
 		return steps.Error(measurementDevice.FailCondition(chantico.ConditionJob, "Failed to build SNMP Generator job: %w", err))
 	}
-	if err := controllerutil.SetControllerReference(measurementDevice, job, r.Scheme); err != nil {
+	if err := util.SetControllerReference(measurementDevice, job, r.Scheme); err != nil {
 		return steps.Error(measurementDevice.FailCondition(chantico.ConditionJob, "Failed to set controller reference for SNMP Generator job: %w", err))
 	}
 	if err := r.Create(ctx, job); err != nil {

--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -2,6 +2,7 @@ package volumes
 
 import (
 	configuration "chantico/internal/configuration"
+
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/internal/webapp/internal/html/html.go
+++ b/internal/webapp/internal/html/html.go
@@ -30,7 +30,7 @@ type HomePageData struct {
 }
 
 func (r *TemplateRenderer) RenderHomePage(w io.Writer, d HomePageData) {
-	r.tmpl.ExecuteTemplate(w, "home.html", d)
+	_ = r.tmpl.ExecuteTemplate(w, "home.html", d)
 }
 
 type ErrorPageData struct {
@@ -40,5 +40,5 @@ type ErrorPageData struct {
 }
 
 func (r *TemplateRenderer) RenderErrorPage(w io.Writer, d ErrorPageData) {
-	r.tmpl.ExecuteTemplate(w, "error.html", d)
+	_ = r.tmpl.ExecuteTemplate(w, "error.html", d)
 }

--- a/internal/webapp/internal/kubernetes/kubernetes.go
+++ b/internal/webapp/internal/kubernetes/kubernetes.go
@@ -32,8 +32,12 @@ func New(kubeconfigPath string) (*KubernetesClient, error) {
 	}
 
 	scheme := runtime.NewScheme()
-	corev1.AddToScheme(scheme)
-	v1alpha1.AddToScheme(scheme)
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
 
 	k, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {

--- a/internal/webapp/webapp.go
+++ b/internal/webapp/webapp.go
@@ -112,7 +112,7 @@ func loadConfig(get envGetter) (config, error) {
 
 	if kubeconfigPath := get("KUBECONFIG"); kubeconfigPath != "" {
 		if !pathExists(kubeconfigPath) {
-			errs = append(errs, fmt.Errorf("Kubeconfig not found at %s", kubeconfigPath))
+			errs = append(errs, fmt.Errorf("kubeconfig not found at %s", kubeconfigPath))
 		} else {
 			cfg.KubeconfigPath = kubeconfigPath
 		}

--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -1,9 +1,11 @@
 languages:
-- name: Docker
-- name: Go
-- name: Html
+  - name: Docker
+  - name: Go
+  - name: Html
 exclude:
   - ".*/api/v1alpha1/zz_generated[.]deepcopy[.]go"
+component_base_dirs:
+  - "internal"
 components:
   - name: datacenterresource
     include:
@@ -22,6 +24,7 @@ components:
       - ".*/internal/physicalmeasurement/.*"
 dependencychecker:
   blocklist:
-  - .*tno.*
+    - .*tno.*
 thirdpartyfindings:
   enabled: true
+


### PR DESCRIPTION
## Description

We want to ideally have the controller components and other components again. This PR intends to see if Sigrid picks up on both `component_base_dirs` and `components` and augments the latter with any remainders, separating them out again. If not, then we go back to our previous configuration.

This PR contains some lint/style fixes in a few components to let Sigrid pick up the changes.

## How to test

See results from Sigrid PR review to find out if our component composition has changed dramatically

## Linked issue

Closes #183 

## Chantico pull request checklist

Please review how the following criteria apply to your pull request changes by ticking off the corresponding boxes. If any of the boxes is not applicable to your pull request changes, please explain why.

### Code quality
- [x] The code meets our coding standards and styling guidelines as listed [here](https://chantico-project.github.io/chantico/technical/coding-style-guidelines/).

### Tests
- [x] Unit tests reflect the changes in the code.
- [x] The code has been tested in a local environment.

### Documentation
- [x] The new changes are reflected into the documentation.
